### PR TITLE
Check allocatable space correctly when sideloading on VAB

### DIFF
--- a/dynamic_partition_control_android.cc
+++ b/dynamic_partition_control_android.cc
@@ -795,7 +795,12 @@ bool DynamicPartitionControlAndroid::UpdatePartitionMetadata(
 
   std::string expr;
   uint64_t allocatable_space = builder->AllocatableSpace();
-  if (!GetDynamicPartitionsFeatureFlag().IsRetrofit()) {
+  // On device retrofitting dynamic partitions, allocatable_space = super.
+  // On device launching dynamic partitions w/o VAB,
+  //   allocatable_space = super / 2.
+  // On device launching dynamic partitions with VAB, allocatable_space = super.
+  if (!GetDynamicPartitionsFeatureFlag().IsRetrofit() &&
+      !GetVirtualAbFeatureFlag().IsEnabled()) {
     allocatable_space /= 2;
     expr = "half of ";
   }


### PR DESCRIPTION
Picked single logical fix for this error.  See bug for details.

Test: pre-submit

Bug: 169781891
Change-Id: I4facf2cd157143846c873e2b458d37356692d68c

This commit fixes flashing SSOS on Virtual A/B devices such as renoir (Mi 11 Lite 5G)